### PR TITLE
Update the data migration utility to use the latest GraphCMS API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,165 @@
 {
   "name": "graphcms-data-migration",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "graphcms-data-migration",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^0.18.0",
+        "csvtojson": "^2.0.8",
+        "dotenv": "^6.1.0",
+        "isomorphic-fetch": "^2.2.1"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.18.0",
+      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "deprecated": "Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410",
+      "dependencies": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+    },
+    "node_modules/csvtojson": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/csvtojson/-/csvtojson-2.0.8.tgz",
+      "integrity": "sha512-DC6YFtsJiA7t/Yz+KjzT6GXuKtU/5gRbbl7HJqvDVVir+dxdw2/1EgwfgJdnsvUT7lOnON5DvGftKuYWX1nMOQ==",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "lodash": "^4.17.3",
+        "strip-bom": "^2.0.0"
+      },
+      "bin": {
+        "csvtojson": "bin/csvtojson"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.1.0.tgz",
+      "integrity": "sha512-/veDn2ztgRlB7gKmE3i9f6CmDIyXAy6d5nBq+whO9SLX+Zs1sXEgFLPi+aSuWqUuusMfbi84fT8j34fs1HaYUw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dependencies": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.9.tgz",
+      "integrity": "sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==",
+      "dependencies": {
+        "debug": "=3.1.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+    },
+    "node_modules/isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dependencies": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dependencies": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dependencies": {
+        "is-utf8": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+    }
+  },
   "dependencies": {
     "axios": {
       "version": "0.18.0",

--- a/src/categories.js
+++ b/src/categories.js
@@ -25,7 +25,6 @@ const categoryPublishMutation = `
   }
 `
 
-// Upload Data to GraphCMS Project Database
 async function uploadCategories(){
   const rows = await csv().fromFile('./data/categories.csv')
   console.log(`Uploading ${rows.length} categories...`)

--- a/src/categories.js
+++ b/src/categories.js
@@ -1,7 +1,7 @@
-const { postMutation } = require('./util/mutation');
-const csv = require('csvtojson');
+const { postMutation } = require('./util/mutation')
+const csv = require('csvtojson')
 
-const categoriesCreateMutation = `
+const categoryCreateMutation = `
   mutation CreateCategory( $name: String! ) {
     createCategory(data: {
       name: $name
@@ -13,7 +13,7 @@ const categoriesCreateMutation = `
   }
 `
 
-const categoriesPublishMutation = `
+const categoryPublishMutation = `
   mutation PublishCategory( $id: ID ) {
     publishCategory(where: {
       id: $id
@@ -27,23 +27,23 @@ const categoriesPublishMutation = `
 
 // Upload Data to GraphCMS Project Database
 async function uploadCategories(){
-  const rows = await csv().fromFile('./data/categories.csv');
-  console.log(`Uploading ${rows.length} categories...`);
-  rows.map(async row => {
-    const createResult = await postMutation(JSON.stringify({
-      query: categoriesCreateMutation,
+  const rows = await csv().fromFile('./data/categories.csv')
+  console.log(`Uploading ${rows.length} categories...`)
+
+  return Promise.all(rows.map(async row => {
+    const createResult = await postMutation({
+      query: categoryCreateMutation,
       variables: row
-    }))
+    })
     const categoryId = createResult.createCategory.id
-    const publishResult = await postMutation(JSON.stringify({
-      query: categoriesPublishMutation,
+    const publishResult = await postMutation({
+      query: categoryPublishMutation,
       variables: {
         id: categoryId
       }
-    }))
+    })
     return publishResult
-  })
-  return true;
+  }))
 }
 
 uploadCategories();

--- a/src/categories.js
+++ b/src/categories.js
@@ -45,7 +45,7 @@ async function uploadCategories(){
   }))
 }
 
-uploadCategories();
+uploadCategories()
 
 module.exports = {
   uploadCategories

--- a/src/config.js
+++ b/src/config.js
@@ -1,9 +1,9 @@
-require('dotenv').config();
-const { ENDPOINT, TOKEN } = process.env;
+require('dotenv').config()
+const { ENDPOINT, TOKEN } = process.env
 
 if (!ENDPOINT || !TOKEN) {
   console.error('ERROR: Failed to load ENDPOINT and TOKEN values from .env file.')
-  process.exit(1);
+  process.exit(1)
 }
 
 const headers = {

--- a/src/posts.js
+++ b/src/posts.js
@@ -26,6 +26,23 @@ const postCreateMutation = `
   }
 `
 
+const postPublishMutation = `
+  mutation PublishPost( $id: ID ) {
+    publishPost(where: {
+      id: $id
+    }, to: PUBLISHED)
+    {
+      id
+      title
+      content
+      slug
+      categories {
+        id
+      }
+    }
+  }
+`
+
 function getCategoryByName(categories, name) {
   return categories.find(category => (category.name === name))
 }
@@ -53,8 +70,14 @@ async function uploadPosts() {
         categories: categoryIds
       }
     })
-    //TODO: Also publish the created post
-    return createResult
+    const postId = createResult.createPost.id
+    const publishResult = await postMutation({
+      query: postPublishMutation,
+      variables: {
+        id: postId
+      }
+    })
+    return publishResult
   }))
 }
 

--- a/src/posts.js
+++ b/src/posts.js
@@ -81,7 +81,7 @@ async function uploadPosts() {
   }))
 }
 
-uploadPosts();
+uploadPosts()
 
 module.exports = {
   uploadPosts

--- a/src/reset.js
+++ b/src/reset.js
@@ -1,59 +1,55 @@
-const { ENDPOINT, headers } = require('./config');
-const fetch = require('isomorphic-fetch');
+const { postMutation } = require('./util/mutation')
 
-// Comments Reset Mutation
-const commentsMutation = `
+const deleteAllCommentsMutation = `
   mutation DeleteAllComments {
-    deleteManyComments(where: {
-      status: PUBLISHED
-    })
+    deleteManyCommentsConnection()
     {
-      count
+      edges {
+        node {
+          id
+        }
+      }
     }
   }`;
 
-// Posts Reset Mutation
-const postsMutation = `
+const deleteAllPostsMutation = `
   mutation DeleteAllPosts {
-    deleteManyPosts(where: {
-      status: PUBLISHED
-    })
+    deleteManyPostsConnection()
     {
-      count
+      edges {
+        node {
+          id
+        }
+      }
     }
   }`;
 
-// Categories Reset Mutation
-const categoriesMutation = `
+const deleteAllCategoriesMutation = `
   mutation DeleteAllCategories {
-    deleteManyCategories(where: {
-      status: PUBLISHED
-    })
+    deleteManyCategoriesConnection()
     {
-      count
+      edges {
+        node {
+          id
+        }
+      }
     }
   }`;
 
-async function deleteModel(mutation) {
-  try {
-    const response = await fetch(ENDPOINT, {
-      headers,
-      method: 'POST',
-      body: JSON.stringify({
-        query: mutation
-      })
-    });
-
-    // Parse the response to verify success
-    const body = await response.json()
-    const data = await body.data
-
-    console.log('Deleted', data)
-  } catch (error) {
-    console.log("Error!", error)
-  }
+async function reset() {
+  await postMutation({
+    query: deleteAllCommentsMutation
+  })
+  await postMutation({
+    query: deleteAllPostsMutation
+  })
+  await postMutation({
+    query: deleteAllCategoriesMutation
+  })
 }
 
-deleteModel(commentsMutation);
-deleteModel(postsMutation);
-deleteModel(categoriesMutation);
+reset()
+
+module.exports = {
+  reset
+}

--- a/src/util/mutation.js
+++ b/src/util/mutation.js
@@ -1,29 +1,45 @@
-const { ENDPOINT, headers } = require('../config');
-const fetch = require('isomorphic-fetch');
+const { ENDPOINT, headers } = require('../config')
+const fetch = require('isomorphic-fetch')
 
 async function postMutation(mutationBody) {
   try{
     const response = await fetch(ENDPOINT, {
       headers,
       method: 'POST',
-      body: mutationBody
-    });
+      body: JSON.stringify(mutationBody)
+    })
 
-    // Parse the response to verify success
     const body = await response.json()
     const data = await body.data
     if (body.errors && body.errors.length > 0) {
       console.error('Failed to post mutation', body)
     } else {
-      console.log('Successfuly posted mutation', data);
+      console.log('Successfuly posted mutation', data)
     }
-    return data;
+    return data
   } catch (error) {
-    console.log("Error!", error);
-    process.exit(1);
+    console.log("Error!", error)
+    process.exit(1)
+  }
+}
+
+async function fetchByQuery(queryBody) {
+  try {
+    const response = await fetch(ENDPOINT, {
+      headers: headers,
+      method: 'POST',
+      body: JSON.stringify(queryBody)
+    })
+
+    const body = await response.json()
+    return await body.data
+  } catch (error) {
+    console.log("Error!", error)
+    process.exit(1)
   }
 }
 
 module.exports = {
-  postMutation
+  postMutation,
+  fetchByQuery
 }

--- a/src/util/mutation.js
+++ b/src/util/mutation.js
@@ -18,6 +18,7 @@ async function postMutation(mutationBody) {
     }
     return data
   } catch (error) {
+    console.log(body)
     console.log("Error!", error)
     process.exit(1)
   }
@@ -34,6 +35,7 @@ async function fetchByQuery(queryBody) {
     const body = await response.json()
     return await body.data
   } catch (error) {
+    console.log(body)
     console.log("Error!", error)
     process.exit(1)
   }

--- a/src/util/mutation.js
+++ b/src/util/mutation.js
@@ -1,0 +1,29 @@
+const { ENDPOINT, headers } = require('../config');
+const fetch = require('isomorphic-fetch');
+
+async function postMutation(mutationBody) {
+  try{
+    const response = await fetch(ENDPOINT, {
+      headers,
+      method: 'POST',
+      body: mutationBody
+    });
+
+    // Parse the response to verify success
+    const body = await response.json()
+    const data = await body.data
+    if (body.errors && body.errors.length > 0) {
+      console.error('Failed to post mutation', body)
+    } else {
+      console.log('Successfuly posted mutation', data);
+    }
+    return data;
+  } catch (error) {
+    console.log("Error!", error);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  postMutation
+}

--- a/src/util/mutation.js
+++ b/src/util/mutation.js
@@ -26,7 +26,7 @@ async function postMutation(mutationBody) {
 async function fetchByQuery(queryBody) {
   try {
     const response = await fetch(ENDPOINT, {
-      headers: headers,
+      headers,
       method: 'POST',
       body: JSON.stringify(queryBody)
     })


### PR DESCRIPTION
Noticed that there were a few breaking changes in the Content API of GraphCMS https://graphcms.com/docs/api-reference/content-api/ and the code no longer worked "out of the box", some of the changes:

* Two separate calls are required to first create a draft of the content, and then to publish it
* Query for bulk deleting entities is no named differently and does not return count

Updated the migration utility following the docs of GraphCMS